### PR TITLE
Specify a repo by default during package installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,10 +8,10 @@ LABEL description="Docker image containing all dependencies for PheWAS pipeline:
 LABEL Phil Palmer <phil@lifebit.ai>
 
 # Install R dependencies 
-RUN Rscript -e "install.packages('optparse')" && \
-    Rscript -e "install.packages('forestplot')" && \
-    Rscript -e "install.packages('data.table')" && \
-    Rscript -e "install.packages('lmtest')"
+RUN Rscript -e "install.packages('optparse', repos = 'http://cran.us.r-project.org')" && \
+    Rscript -e "install.packages('forestplot', repos = 'http://cran.us.r-project.org')" && \
+    Rscript -e "install.packages('data.table', repos = 'http://cran.us.r-project.org')" && \
+    Rscript -e "install.packages('lmtest', repos = 'http://cran.us.r-project.org')"
 
 RUN mkdir /data && \
     mkdir /data/scripts/


### PR DESCRIPTION
At least for me, the `Rscript` package installation step fails because I don't have a repo specified. This change adds a default repo to permit the step to complete.